### PR TITLE
Actualizar textos de tipos de pago

### DIFF
--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -574,7 +574,7 @@ const processPayments = async (playerId, formData, temporadaActiva) => {
             total_abonado: 0
           },
           {
-            tipo: 'Equipamiento',
+            tipo: 'Pesaje',
             estatus: 'pendiente',
             fecha_pago: null,
             fecha_limite: null,
@@ -585,7 +585,7 @@ const processPayments = async (playerId, formData, temporadaActiva) => {
             total_abonado: 0
           },
           {
-            tipo: 'Pesaje',
+            tipo: 'Primera Jornada',
             estatus: 'pendiente',
             fecha_pago: null,
             monto: pesaje,


### PR DESCRIPTION
## Cambios realizados:
- Cambiar "Pago de equipamiento" por "Pago de Pesaje"
- Cambiar "Pago de pesaje" por "Pago de Primera Jornada"

## Archivos modificados:
- screens/HomeScreen.js (líneas 577 y 588)

Solo se cambiaron las etiquetas de texto, la funcionalidad permanece igual.